### PR TITLE
NewConn get stuck if not handling the empty line

### DIFF
--- a/agi.go
+++ b/agi.go
@@ -128,6 +128,9 @@ func NewWithEAGI(r io.Reader, w io.Writer, eagi io.Reader) *AGI {
 
 	s := bufio.NewScanner(a.r)
 	for s.Scan() {
+		if s.Text() == "" {
+			break
+		}
 		terms := strings.Split(s.Text(), ":")
 		if len(terms) == 2 {
 			a.Variables[strings.TrimSpace(terms[0])] = strings.TrimSpace(terms[1])


### PR DESCRIPTION
I am using this library over tcp and I noticed that it get stuck in the `bufio.Scanner` loop (I am on asterisk 13). 

I have added a check to catch if the line is empty and break the for in that case

 