### PR TITLE
Changed how return value of WaitForDigit is built

### DIFF
--- a/agi.go
+++ b/agi.go
@@ -413,5 +413,6 @@ func (a *AGI) Verbose(msg string, level int) error {
 
 // WaitForDigit waits for a DTMF digit and returns what is received
 func (a *AGI) WaitForDigit(timeout time.Duration) (digit string, err error) {
-	return a.Command("WAIT FOR DIGIT", toMSec(timeout)).Val()
+	resp := a.Command("WAIT FOR DIGIT", toMSec(timeout))
+	return string(resp.Result), resp.Error
 }


### PR DESCRIPTION
WaitForDigit should return the pressed digit as result. Asterisk result value should be parsed as ASCII char.