### PR TITLE
Fix split line with colon in variable value

### DIFF
--- a/agi.go
+++ b/agi.go
@@ -132,7 +132,7 @@ func NewWithEAGI(r io.Reader, w io.Writer, eagi io.Reader) *AGI {
 			break
 		}
 
-		terms := strings.Split(s.Text(), ":")
+		terms := strings.SplitN(s.Text(), ":", 2)
 		if len(terms) == 2 {
 			a.Variables[strings.TrimSpace(terms[0])] = strings.TrimSpace(terms[1])
 		}


### PR DESCRIPTION
Hello.
If a colon is present in the value of a variable, it is ignored.
Example:
`exten => 1,1,AGI(executable,http://localhost/)`
"http://localhost/" will be passed as variable "agi_arg_1", but it is ignored because string contains more than 1 colon and is splitted into more than 2 parts.